### PR TITLE
Optimized Live stat-tracking & Database writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,9 @@ node_modules/
 
 # dataconnect generated files
 .dataconnect
+
+# Ignore Cursor workspace data
+.cursor/
+
+# Ignore Node.js dependencies
+node_modules/

--- a/auth/profile.html
+++ b/auth/profile.html
@@ -67,7 +67,8 @@
         import { auth } from './firebase-config.js';
         import { getUserData, logoutUser } from './auth-service.js';
         import { onAuthStateChanged } from 'firebase/auth';
-        import { updateGameStats } from '../game/statistics.js';
+        import { updateGameStats, gameStats, loadGameStatsFromStorage } from '../game/statistics.js';
+        import { updateUserStats } from './auth-service.js';
 
         const countries = [
             { code: 'af', name: 'Afghanistan' },
@@ -152,6 +153,12 @@
 
         onAuthStateChanged(auth, async (user) => {
             if (user) {
+                // Load latest stats from localStorage and update Firestore if needed
+                loadGameStatsFromStorage();
+                await updateUserStats(user.uid, gameStats);
+                localStorage.removeItem('latestGameStats');
+
+                // Now fetch the latest stats from Firestore and display them
                 const result = await getUserData(user.uid);
                 if (result.success) {
                     const userData = result.data;
@@ -190,6 +197,9 @@
             }
         });
 
+        window.addEventListener('unload', () => {
+            // clearInterval(refreshInterval); // No longer needed since interval is removed
+        });
     </script>
 </body>
 </html> 

--- a/auth/profile.html
+++ b/auth/profile.html
@@ -67,6 +67,7 @@
         import { auth } from './firebase-config.js';
         import { getUserData, logoutUser } from './auth-service.js';
         import { onAuthStateChanged } from 'firebase/auth';
+        import { updateGameStats } from '../game/statistics.js';
 
         const countries = [
             { code: 'af', name: 'Afghanistan' },
@@ -157,9 +158,12 @@
                     document.getElementById('profileUsername').textContent = userData.username;
                     document.getElementById('profileEmail').textContent = userData.email;
                     
-                    const countryCode = userData.nationality.toLowerCase();
+                    const countryCode = (userData.nationality || 'xx').toLowerCase();
                     document.getElementById('profileNationality').textContent = getCountryName(countryCode);
                     document.getElementById('profileFlag').src = `https://flagcdn.com/w40/${countryCode}.png`;
+                    document.getElementById('profileFlag').onerror = function() {
+                        this.src = 'https://flagcdn.com/w40/xx.png';
+                    };
                     
                     const date = new Date(userData.dateCreated.seconds * 1000);
                     const formattedDate = date.toLocaleDateString('en-US', {
@@ -179,7 +183,6 @@
                     });
 
                     clearInterval(refreshInterval); 
-                    refreshInterval = setInterval(() => refreshUserData(user.uid), 30000);
                 }
             } else {
                 clearInterval(refreshInterval); 
@@ -187,9 +190,6 @@
             }
         });
 
-        window.addEventListener('unload', () => {
-            clearInterval(refreshInterval);
-        });
     </script>
 </body>
 </html> 

--- a/game/game.js
+++ b/game/game.js
@@ -8,7 +8,8 @@ import { getWave, tryEndWave } from "./wave.js";
 import { GatlingTower } from "../entities/towers/GatlingTower.js";
 import { getTowerPrice } from "./towerUnlockSystem.js";
 import { soundManager } from './soundManager.js';
-import { recordResourcesGathered, recordEnemyKilled, recordMoneySpent, recordWaveReached, recordBossStage } from './statistics.js';
+import { recordResourcesGathered, recordEnemyKilled, recordMoneySpent, recordWaveReached, recordBossStage, updateGameStats } from './statistics.js';
+import { toastInfo } from './toast-message.js';
 
 
 export const canvas = document.getElementById("gameCanvas");
@@ -147,6 +148,8 @@ export function updateGameState(deltaTime) {
     
     if (resources <= 0) {
         gameOver = true;
+        toastInfo("Saving stats to leaderboard");
+        updateGameStats();
     }
 
     updateTowerStats(selectedTower);

--- a/game/settings.js
+++ b/game/settings.js
@@ -68,7 +68,6 @@ const Settings = {
         }
 
         if (volumeSlider) {
-            this.volume = 1.0;
             volumeSlider.value = this.volume;
             soundManager.setVolume(this.volume);
             volumeSlider.addEventListener('input', (e) => {

--- a/game/statistics.js
+++ b/game/statistics.js
@@ -13,28 +13,28 @@ let gameStats = {
 
 export function recordTowerDamage(damage) {
     gameStats.totalTowerDamage += damage;
-    updateGameStats();
+    updateStatsDisplay();
 }
 
 export function recordResourcesGathered(amount) {
     gameStats.totalResourcesGathered += amount;
-    updateGameStats();
+    updateStatsDisplay();
 }
 
 export function recordEnemyKilled() {
     gameStats.totalEnemiesKilled += 1;
-    updateGameStats();
+    updateStatsDisplay();
 }
 
 export function recordMoneySpent(amount) {
     gameStats.totalMoneySpent += amount;
-    updateGameStats();
+    updateStatsDisplay();
 }
 
 export function recordWaveReached(wave) {
     if (wave > gameStats.highestWaveReached) {
         gameStats.highestWaveReached = wave;
-        updateGameStats();
+        updateStatsDisplay();
     }
 }
 
@@ -69,5 +69,4 @@ export function resetGameStats() {
     updateStatsDisplay();
 }
 
-
-export { gameStats }; 
+export { gameStats, updateGameStats }; 

--- a/game/statistics.js
+++ b/game/statistics.js
@@ -1,6 +1,7 @@
 import { auth } from '../auth/firebase-config.js';
 import { updateUserStats } from '../auth/auth-service.js';
 import { updateStatsDisplay } from './statsDisplay.js';
+import { toastInfo } from './toast-message.js';
 
 let gameStats = {
     totalTowerDamage: 0,
@@ -40,6 +41,7 @@ export function recordWaveReached(wave) {
 
 export function recordBossStage() {
     gameStats.totalBossStagesReached += 1;
+    toastInfo("Saving stats to leaderboard");
     updateGameStats();
 }
 
@@ -50,6 +52,7 @@ async function updateGameStats() {
     // Update the database
     if (auth.currentUser) {
         const result = await updateUserStats(auth.currentUser.uid, gameStats);
+        console.log("Stats updated " + result);
  
         if (!result.success) {
             console.error("Failed to update stats:", result.error);

--- a/game/statistics.js
+++ b/game/statistics.js
@@ -48,7 +48,8 @@ export function recordBossStage() {
 async function updateGameStats() {
     // Update the display
     updateStatsDisplay();
-    
+    // Save to localStorage for cross-page persistence
+    localStorage.setItem('latestGameStats', JSON.stringify(gameStats));
     // Update the database
     if (auth.currentUser) {
         const result = await updateUserStats(auth.currentUser.uid, gameStats);
@@ -56,6 +57,18 @@ async function updateGameStats() {
  
         if (!result.success) {
             console.error("Failed to update stats:", result.error);
+        }
+    }
+}
+
+export function loadGameStatsFromStorage() {
+    const saved = localStorage.getItem('latestGameStats');
+    if (saved) {
+        try {
+            const parsed = JSON.parse(saved);
+            Object.assign(gameStats, parsed);
+        } catch (e) {
+            console.error('Failed to parse saved game stats:', e);
         }
     }
 }

--- a/main.js
+++ b/main.js
@@ -6,6 +6,8 @@ import { projectiles } from "./entities/projectiles/projectiles.js";
 import { enemies } from "./entities/enemies/enemy.js";
 import { towers} from "./entities/towers/tower.js"
 import { soundManager } from "./game/soundManager.js";
+import { updateGameStats } from './game/statistics.js';
+import { initAuthState } from './auth/auth-state.js';
 
 /**
  * Main game loop and initialization              
@@ -13,6 +15,8 @@ import { soundManager } from "./game/soundManager.js";
  * @contributor: Randomfevva, Quetzalcoatl
  * Created:   11.02.2025
 **/
+
+initAuthState();
 
 initGame().then(() => {
     gameLoop();
@@ -72,3 +76,16 @@ window.printCounters = e => {
 }
 
 // setInterval(printCounters, 2e3);
+
+/*
+ * Save game stats before the tab closes
+ * @author:    Anarox
+ * @contributor: Randomfevva
+ * Created:   19.06.2025
+*/
+window.addEventListener('beforeunload', (event) => {
+    // Attempt to write stats before the tab closes
+    if (typeof updateGameStats === 'function') {
+        updateGameStats();
+    }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1898,9 +1898,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.3.tgz",
-      "integrity": "sha512-5nXH+QsELbFKhsEfWLkHrvgRpTdGJzqOZ+utSdmPTvwHmvU6ITTm3xx+mRusihkcI8GeC7lCDyn3kDtiki9scw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
**1.** Now player-stats will be written to database when you die, if you close tab or browser, redirecting to profile, or when you reach a boss-wave as a set of auto-saving.

**2.** Now volumeslider remembers in localStorage what volume value is set to in browser. Also now works on refresh

**3.** Now profile fetches data from firestore correctly. Current gameStats when playing will be added to localstorage in order to save current stats from in-memory.